### PR TITLE
修复 NeoForge 26.1.2/26.2 客户端指令空玩家导致的 NPE

### DIFF
--- a/neoforge/src/main/java/top/vmctcn/vmtu/mod/neoforge/VMTranslationUpdateModClientNeoForge.java
+++ b/neoforge/src/main/java/top/vmctcn/vmtu/mod/neoforge/VMTranslationUpdateModClientNeoForge.java
@@ -1,6 +1,9 @@
 package top.vmctcn.vmtu.mod.neoforge;
 
 import com.mojang.brigadier.Command;
+//? if >=26.1.2 {
+import net.minecraft.client.Minecraft;
+//?}
 import net.minecraft.commands.Commands;
 //? if >=1.20.6 {
 import net.neoforged.api.distmarker.Dist;
@@ -55,14 +58,14 @@ public class VMTranslationUpdateModClientNeoForge {
                 event.getDispatcher().register(
                         Commands.literal("vmtu")
                                 .then(Commands.literal("check").executes(context -> {
-                                    ModEvents.checkTranslationUpdateCommand(context.getSource().getPlayer());
-                                    ModEvents.checkModpackUpdateCommand(context.getSource().getPlayer());
+                                    ModEvents.checkTranslationUpdateCommand(/*? if >=26.1.2 {*/Minecraft.getInstance().player/*?} else {*//*context.getSource().getPlayer()*//*?}*/);
+                                    ModEvents.checkModpackUpdateCommand(/*? if >=26.1.2 {*/Minecraft.getInstance().player/*?} else {*//*context.getSource().getPlayer()*//*?}*/);
                                     return Command.SINGLE_SUCCESS;
                                 }).then(Commands.literal("modpack").executes(context -> {
-                                    ModEvents.checkModpackUpdateCommand(context.getSource().getPlayer());
+                                    ModEvents.checkModpackUpdateCommand(/*? if >=26.1.2 {*/Minecraft.getInstance().player/*?} else {*//*context.getSource().getPlayer()*//*?}*/);
                                     return Command.SINGLE_SUCCESS;
                                 })).then(Commands.literal("translation").executes(context -> {
-                                    ModEvents.checkTranslationUpdateCommand(context.getSource().getPlayer());
+                                    ModEvents.checkTranslationUpdateCommand(/*? if >=26.1.2 {*/Minecraft.getInstance().player/*?} else {*//*context.getSource().getPlayer()*//*?}*/);
                                     return Command.SINGLE_SUCCESS;
                                 })))
                 );


### PR DESCRIPTION
### Motivation

- 新版 NeoForge 在客户端注册命令时通过 `context.getSource().getPlayer()` 获取玩家会在某些环境下返回 `null`，触发 `NullPointerException`，导致 `/vmtu check` 等命令无法执行。 
- 需要在不破坏对旧版本兼容性的前提下修复该问题，使用条件注释在高版本中改为使用客户端当前玩家。 

### Description

- 在 `neoforge/src/main/java/top/vmctcn/vmtu/mod/neoforge/VMTranslationUpdateModClientNeoForge.java` 中添加了 Stonecutter 条件注释并在 `>=26.1.2` 情况下导入 `Minecraft`。 
- 将命令处理回调中对玩家的取用从 `context.getSource().getPlayer()` 改为在 `>=26.1.2` 时使用 `Minecraft.getInstance().player`，并保留对旧版的兼容占位注释。 
- 此修改仅影响 NeoForge 客户端命令注册（`/vmtu check`、`/vmtu check modpack`、`/vmtu check translation`）的玩家来源逻辑，避免因 `player` 为 `null` 抛出异常。 

### Testing

- 运行 `./gradlew --configure-on-demand :neoforge:26.2:build` 并得到 `BUILD SUCCESSFUL`，构建通过。 
- 运行 `./gradlew --configure-on-demand :neoforge:26.1.2:compileJava :neoforge:1.21.11:compileJava` 并得到成功退出，相关版本的编译通过。 
- 进行了差异/检查类静态检查（`git diff --check`）和构建流程的验证，未发现报错。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9cc91afee48333aa7a0c7bf9aabcb6)